### PR TITLE
Fix missing default export for PropertyCard

### DIFF
--- a/components/PropertyCard.tsx
+++ b/components/PropertyCard.tsx
@@ -233,3 +233,4 @@ const styles = StyleSheet.create({
     marginLeft: 4,
   },
 });
+export default PropertyCard;


### PR DESCRIPTION
## Summary
- fix missing default export in `PropertyCard` so pages that import it default function correctly

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6840a575ce9c8325a15f6776de02b70c